### PR TITLE
Link OpenSSL statically on Linux, enable Wayland support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Cache Nodegit build
+        if: runner.os == 'Linux'
+        uses: actions/cache@v3
+        with:
+          path: .yarn/unplugged/nodegit-*
+          key: ${{ runner.os }}-${{ hashFiles('.yarn/unplugged/nodegit-*/node_modules/nodegit/package.json') }}
+
       - name: Build/sign/release Electron macOS app
         if: runner.os == 'macOS'
         run: yarn package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,16 @@ jobs:
           NOTARIZE_APPLE_ID_PASS: ${{ secrets.NOTARIZE_APPLE_ID_PASS }}
           NOTARIZE_TEAM_ID: ${{ secrets.NOTARIZE_TEAM_ID }}
 
-      - name: Build/release Electron app
-        if: runner.os != 'macOS'
+      - name: Build/release Electron Linux app
+        if: runner.os == 'Linux'
+        run: yarn package
+        env:
+          GH_TOKEN: ${{ github.ref == 'refs/heads/master' && secrets.RELEASE_REPO_TOKEN || secrets.github_token }}
+          BUILD_ONLY: "1"
+          NODEGIT_OPENSSL_STATIC_LINK: "1"
+
+      - name: Build/release Electron Windows app
+        if: runner.os == 'Windows'
         run: yarn package
         env:
           GH_TOKEN: ${{ github.ref == 'refs/heads/master' && secrets.RELEASE_REPO_TOKEN || secrets.github_token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -29,12 +29,12 @@ jobs:
           version: 1.0
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: Cache Electron-Builder
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ github.workspace }}/.cache/electron
@@ -64,7 +64,7 @@ jobs:
           GH_TOKEN: ${{ github.ref == 'refs/heads/master' && secrets.RELEASE_REPO_TOKEN || secrets.github_token }}
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ runner.os }} Release Build
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-20.04, windows-latest]
 
     env:
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
@@ -20,6 +20,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Install Dependencies for Ubuntu
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        if: runner.os == 'Linux'
+        with:
+          packages: libssl-dev libkrb5-dev
+          version: 1.0
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Electron has been upgraded to v21.4.0
 - macOS packages are now code-signed (thanks to [Tiffinger & Thiel GmbH](https://www.tiffinger-thiel.de)!)
+- On Linux, Wayland display mode will be used automatically, matching the current XDG session
 - The git conflict view now gives detailed information on which commit caused the conflict,
   and which files are affected
 - Search now behaves more like a fulltext search engine, scoring results by quality instead of filtering.
@@ -14,6 +15,7 @@
 - Regression on "Open in default application" has been fixed (#8)
 - Errors when encoutering git merge conflicts have been fixed (#9)
 - Ctrl+L shortcut now works when the search field is focused
+- OpenSSL is now statically linked on Linux (#15)
 
 ## v1.2.2 (2020-11-28)
 

--- a/internals/scripts/build.ts
+++ b/internals/scripts/build.ts
@@ -14,8 +14,12 @@ if (process.argv[2] === 'all' || process.argv.slice(2).includes('mac') || (!proc
 }
 
 function makeConfig(platform: Platform, version: semver.SemVer, snapshotNum?: number): CliOptions {
+  let platformArgs = {};
+  if (platform === Platform.LINUX) {
+    platformArgs = { BUILD_ONLY: '1', NODEGIT_OPENSSL_STATIC_LINK: '1' };
+  }
   spawnSync(process.env.npm_execpath || 'yarn', ['rebuild'], {
-    env: { ...process.env, npm_config_platform: platform.nodeName, npm_config_target_platform: platform.nodeName },
+    env: { ...process.env, npm_config_platform: platform.nodeName, npm_config_target_platform: platform.nodeName, ...platformArgs },
     shell: true,
     stdio: 'inherit'
   });

--- a/internals/scripts/build.ts
+++ b/internals/scripts/build.ts
@@ -14,12 +14,8 @@ if (process.argv[2] === 'all' || process.argv.slice(2).includes('mac') || (!proc
 }
 
 function makeConfig(platform: Platform, version: semver.SemVer, snapshotNum?: number): CliOptions {
-  let platformArgs = {};
-  if (platform === Platform.LINUX) {
-    platformArgs = { BUILD_ONLY: '1', NODEGIT_OPENSSL_STATIC_LINK: '1' };
-  }
   spawnSync(process.env.npm_execpath || 'yarn', ['rebuild'], {
-    env: { ...process.env, npm_config_platform: platform.nodeName, npm_config_target_platform: platform.nodeName, ...platformArgs },
+    env: { ...process.env, npm_config_platform: platform.nodeName, npm_config_target_platform: platform.nodeName },
     shell: true,
     stdio: 'inherit'
   });

--- a/package.json
+++ b/package.json
@@ -88,7 +88,11 @@
       "desktop": {
         "StartupWMClass": "Stash",
         "MimeType": "x-scheme-handler/stash;"
-      }
+      },
+      "executableArgs": [
+        "--ozone-platform-hint=auto",
+        "--enable-features=WaylandWindowDecorations"
+      ]
     },
     "deb": {
       "depends": [


### PR DESCRIPTION
* Set the `--ozone-platform-hint=auto` flag in desktop files to run in Wayland mode if available
* Rebuild nodegit during Linux release build with OpenSSL linked statically to remove dependency on system OpenSSL version

Fixes #15 